### PR TITLE
Add new section about flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,13 @@ Extract the contents of the plugin into _/wwwroot/mod_ then visit `admin/upgrade
 
 For more information about installation, configuration and usage, please see https://help.blackboard.com/Collaborate
 
+## Flag
+
+### The  `mod_collaborate_migration_data_limit` flag.
+### The  `mod_collaborate_alternative_counter` flag.
+### The  `use_collab_test_api` flag.
+### The  `mod_collaborate_show_migration_button` flag.
+
 ## License
 Copyright (c) 2021 Open LMS (https://www.openlms.net)
 


### PR DESCRIPTION
**This commit adds a new section to the documentation titled "Flag" and includes information about several flags used in the application:** 

1. `mod_collaborate_migration_data_limit`,
2.  `mod_collaborate_alternative_counter`,
3.  `use_collab_test_api`,
4. `mod_collaborate_show_migration_button`. 


> Each flag is briefly described to provide users with an overview of their purpose.