### PR TITLE
Fix_deprecation_utf8_decode

### DIFF
--- a/vendor/symfony/polyfill-iconv/Iconv.php
+++ b/vendor/symfony/polyfill-iconv/Iconv.php
@@ -440,7 +440,7 @@ final class Iconv
             return false;
         }
 
-        return strlen(utf8_decode($s));
+        return mb_strlen($s, 'UTF-8');
     }
 
     public static function strlen2($s, $encoding = null)


### PR DESCRIPTION
Updated the strlen1 function in the Iconv class to use mb_strlen for character counting. This change addresses the deprecation of utf8_decode in PHP 8.2 and ensures accurate character counting for UTF-8 strings, including those with multi-byte characters. The pollyfill-iconv component has not yet been updated to reflect this deprecation, making this change necessary for compatibility with newer PHP versions.